### PR TITLE
Adding uWSGI stats server access

### DIFF
--- a/app/_docker_app_script.sh
+++ b/app/_docker_app_script.sh
@@ -26,6 +26,6 @@ if [ "$CONTAINER_MODE" = 'TEST' ]; then
    fi
    bash <(curl -s https://codecov.io/bash) -cF python
 else
-  uwsgi --socket 0.0.0.0:9000 --protocol http  --processes 4 --enable-threads --module=server.wsgi:app
+  uwsgi --socket 0.0.0.0:9000 --protocol http  --processes 4 --enable-threads --module=server.wsgi:app --stats :3031  --stats-http
 fi
 


### PR DESCRIPTION
uWSGI docs recommend using the [stats server/uwsgitop](https://uwsgi-docs.readthedocs.io/en/latest/StatsServer.html) to monitor apps and understand performance issues. See also https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html

This PR adds this 
