### PR TITLE
Choose correct organisation for self-service wallet

### DIFF
--- a/app/server/api/ussd_api.py
+++ b/app/server/api/ussd_api.py
@@ -8,8 +8,9 @@ from server.utils.user import get_user_by_phone, create_user_without_transfer_ac
 from server.utils.ussd.kenya_ussd_processor import KenyaUssdProcessor
 from server.utils.ussd.ussd import menu_display_text_in_lang, create_or_update_session
 
-ussd_blueprint = Blueprint('ussd', __name__)
+import config
 
+ussd_blueprint = Blueprint('ussd', __name__)
 
 class ProcessKenyaUssd(MethodView):
     """
@@ -39,7 +40,11 @@ class ProcessKenyaUssd(MethodView):
             # api chains all inputs that came through with *
             latest_input = user_input.split('*')[-1]
             if None in [user, session_id]:
-                user_without_transfer_account = create_user_without_transfer_account(phone_number)
+                default_token = Token.query.filter(Token.symbol==config.DEFAULT_LIQUID_TOKEN_SYMBOL).first()
+                if default_token != None:
+                    logg.debug('attempting to find organisation for default liquid token "{}" {}'.format(config.DEFAULT_LIQUID_TOKEN_SYMBOL, default_token))
+                    default_organisation = Organisation.query.filter(Organisation.token==default_token).first()
+                user_without_transfer_account = create_user_without_transfer_account(phone_number, default_organisation)
                 current_menu = UssdMenu.find_by_name('initial_language_selection')
                 ussd_session = create_or_update_session(session_id=session_id,
                                                         user=user_without_transfer_account,

--- a/app/server/utils/user.py
+++ b/app/server/utils/user.py
@@ -848,8 +848,10 @@ def create_user_without_transfer_account(phone):
 
     organisation = g.active_organisation
 
-    if organisation:
-        user.add_user_to_organisation(organisation, False)
+    if organisation == None:
+        raise Exception('no active organisation')
+
+    user.add_user_to_organisation(organisation, False)
 
     return user
 

--- a/app/server/utils/user.py
+++ b/app/server/utils/user.py
@@ -34,6 +34,8 @@ from server.utils.transfer_enums import TransferSubTypeEnum
 from server.utils.misc import rounded_dollars
 from server.utils.access_control import AccessControl
 
+import logging
+logg = logging.getLogger(__file__)
 
 def save_photo_and_check_for_duplicate(url, new_filename, image_id):
     save_to_s3_from_url(url, new_filename)
@@ -833,7 +835,7 @@ def transfer_usages_for_user(user: User) -> List[TransferUsage]:
     return ordered_transfer_usages
 
 
-def create_user_without_transfer_account(phone):
+def create_user_without_transfer_account(phone, organisation=None):
     """
     This method creates a user without a transfer account or blockchain wallet.
     :param phone: string with user's msisdn
@@ -846,7 +848,9 @@ def create_user_without_transfer_account(phone):
                 phone=phone,
                 registration_method=RegistrationMethodEnum.USSD_SIGNUP)
 
-    organisation = g.active_organisation
+    if organisation == None:
+        organisation = g.active_organisation
+        logg.debug('no organisation given, reverting to session active organisation {}'.format(organisation))
 
     if organisation == None:
         raise Exception('no active organisation')

--- a/config.py
+++ b/config.py
@@ -308,6 +308,8 @@ MASTER_WALLET_ADDRESS = address_from_private_key(master_wallet_private_key)
 RESERVE_TOKEN_ADDRESS = config_parser['ETHEREUM'].get('reserve_token_address')
 RESERVE_TOKEN_NAME = config_parser['ETHEREUM'].get('reserve_token_name')
 RESERVE_TOKEN_SYMBOL = config_parser['ETHEREUM'].get('reserve_token_symbol')
+DEFAULT_LIQUID_TOKEN_NAME = config_parser['ETHEREUM'].get('default_liquid_token_name')
+DEFAULT_LIQUID_TOKEN_SYMBOL = config_parser['ETHEREUM'].get('default_liquid_token_symbol')
 
 SYSTEM_WALLET_TARGET_BALANCE = int(config_parser['ETHEREUM'].get('system_wallet_target_balance', 0))
 SYSTEM_WALLET_TOPUP_THRESHOLD = int(config_parser['ETHEREUM'].get('system_wallet_topup_threshold', 0))

--- a/config_files/public/test_config.ini
+++ b/config_files/public/test_config.ini
@@ -23,6 +23,7 @@ self_service_wallet_initial_disbursement     = 5000
 
 [DATABASE]
 host         = localhost
+port	     = 5432
 database     = sempo_blockchain_test
 eth_database = eth_worker_test
 


### PR DESCRIPTION
Active organisation for ussd session will be `1`, which will add the user to the wrong organisation. This bug would not be detected in staging (because there is only one token there), but would have blown up in prod.