### PR TITLE
Swap SQL Pagination to sort via ID column

### DIFF
--- a/app/server/models/utils.py
+++ b/app/server/models/utils.py
@@ -64,7 +64,7 @@ def paginate_query(query, queried_object=None, order_override=None):
     if order_override:
         query = query.order_by(order_override)
     elif queried_object:
-        query = query.order_by(queried_object.created.desc())
+        query = query.order_by(queried_object.id.desc())
 
     if per_page is None:
 


### PR DESCRIPTION
SQL Pagination currently uses the created column, but this column isn't index. Swapping to ID makes it run way faster