### PR TITLE
Adds ussd send on pin

### DIFF
--- a/app/server/locale/ussd.en.yml
+++ b/app/server/locale/ussd.en.yml
@@ -46,6 +46,7 @@ en:
       first: |
         CON Send %{transaction_amount} %{token_name} to %{recipient_phone}.
         Please enter your PIN to confirm.
+        0. Back
       retry: |
         CON Please enter your PIN. You have %{remaining_attempts} attempts remaining.
         0. Back

--- a/app/server/locale/ussd.en.yml
+++ b/app/server/locale/ussd.en.yml
@@ -44,8 +44,8 @@ en:
         10. Show previous
     send_token_pin_authorization:
       first: |
-        CON Please enter your PIN.
-        0. Back
+        CON Send %{transaction_amount} %{token_name} to %{recipient_phone}.
+        Please enter your PIN to confirm.
       retry: |
         CON Please enter your PIN. You have %{remaining_attempts} attempts remaining.
         0. Back

--- a/app/server/locale/ussd.sw.yml
+++ b/app/server/locale/ussd.sw.yml
@@ -45,9 +45,8 @@ sw:
     send_token_pin_authorization:
       first: |
         CON Tuma %{transaction_amount} %{token_name} kwa %{recipient_phone}.
-                Weka nambari ya siri kuthibitisha.
-                0. Nyuma
-                0. Nyuma
+        Weka nambari ya siri kuthibitisha.
+        0. Nyuma
       retry: |
         CON Weka nambari ya siri. Una majaribio %{remaining_attempts} yaliyobaki.
         0. Nyuma

--- a/app/server/locale/ussd.sw.yml
+++ b/app/server/locale/ussd.sw.yml
@@ -43,16 +43,14 @@ sw:
         %{other_options}
         10. Onyesha chaguzi zilizopita
     send_token_pin_authorization:
-      first: CON Weka nambari ya siri.
-        0. Nyuma
-      retry:
+      first: |
+        CON Tuma %{transaction_amount} %{token_name} kwa %{recipient_phone}.
+                Weka nambari ya siri kuthibitisha.
+                0. Nyuma
+                0. Nyuma
+      retry: |
         CON Weka nambari ya siri. Una majaribio %{remaining_attempts} yaliyobaki.
         0. Nyuma
-    send_token_confirmation: |
-      CON Tuma %{transaction_amount} %{token_name} kwa %{recipient_phone}
-      1. Thibitisha
-      2. Futa
-      0. Nyuma
     directory_listing: |
       CON Sokoni
       %options%

--- a/app/server/utils/ussd/kenya_ussd_processor.py
+++ b/app/server/utils/ussd/kenya_ussd_processor.py
@@ -135,7 +135,7 @@ class KenyaUssdProcessor:
             recipient_phone = recipient.user_details()
             token = default_token(user)
             transaction_amount = ussd_session.get_data('transaction_amount')
-            if user.failed_pin_attempts is not None and user.failed_pin_attempts > 0:
+            if user.failed_pin_attempts > 0:
                 return i18n_for(
                     user=user,
                     key="{}.{}".format(menu.display_key, 'retry'),

--- a/app/server/utils/ussd/kenya_ussd_processor.py
+++ b/app/server/utils/ussd/kenya_ussd_processor.py
@@ -130,19 +130,25 @@ class KenyaUssdProcessor:
                             gender=gender_text,
                             location=location, user_bio=bio_text)
 
-        if menu.name == 'send_token_confirmation':
+        if menu.name == 'send_token_pin_authorization':
             recipient = get_user_by_phone(ussd_session.get_data('recipient_phone'), 'KE', True)
             recipient_phone = recipient.user_details()
             token = default_token(user)
             transaction_amount = ussd_session.get_data('transaction_amount')
-            transaction_reason = ussd_session.get_data('transaction_reason_i18n')
-            return i18n_for(
-                user, menu.display_key,
-                recipient_phone=recipient_phone,
-                token_name=token.symbol,
-                transaction_amount=cents_to_dollars(transaction_amount),
-                transaction_reason=transaction_reason
-            )
+            if user.failed_pin_attempts is not None and user.failed_pin_attempts > 0:
+                return i18n_for(
+                    user=user,
+                    key="{}.{}".format(menu.display_key, 'retry'),
+                    remaining_attempts=3 - user.failed_pin_attempts
+                )
+            else:
+                return i18n_for(
+                    user=user,
+                    key="{}.{}".format(menu.display_key, 'first'),
+                    transaction_amount=cents_to_dollars(transaction_amount),
+                    token_name=token.symbol,
+                    recipient_phone=recipient_phone
+                )
 
         if menu.name == 'exchange_token_confirmation':
             agent = get_user_by_phone(ussd_session.get_data('agent_phone'), 'KE', True)

--- a/app/server/utils/ussd/kenya_ussd_state_machine.py
+++ b/app/server/utils/ussd/kenya_ussd_state_machine.py
@@ -46,7 +46,6 @@ class KenyaUssdStateMachine(Machine):
         'send_token_reason',
         'send_token_reason_other',
         'send_token_pin_authorization',
-        'send_token_confirmation',
         # account management states
         'account_management',
         'balance_inquiry_pin_authorization',
@@ -295,9 +294,7 @@ class KenyaUssdStateMachine(Machine):
     def process_send_token_request(self, user_input):
         user = get_user_by_phone(self.session.get_data('recipient_phone'), "KE")
         amount = float(self.session.get_data('transaction_amount'))
-        reason_str = self.session.get_data('transaction_reason_i18n')
-        reason_id = float(self.session.get_data('transaction_reason_id'))
-        ussd_tasker.send_token(self.user, user, amount, reason_str, reason_id)
+        ussd_tasker.send_token(self.user, recipient=user, amount=amount)
 
     def upsell_unregistered_recipient(self, user_input):
         try:
@@ -536,7 +533,7 @@ class KenyaUssdStateMachine(Machine):
         ]
         self.add_transitions(initial_pin_confirmation_transitions)
 
-        # event: directory_listing
+        # event: start transitions
         start_transitions = [
             {'trigger': 'feed_char',
              'source': 'start',
@@ -587,7 +584,7 @@ class KenyaUssdStateMachine(Machine):
         send_token_amount_transitions = [
             {'trigger': 'feed_char',
              'source': 'send_token_amount',
-             'dest': 'send_token_reason',
+             'dest': 'send_token_pin_authorization',
              'conditions': 'is_valid_token_amount',
              'after': ['save_transaction_amount', 'store_transfer_usage']},
             {'trigger': 'feed_char',
@@ -671,31 +668,15 @@ class KenyaUssdStateMachine(Machine):
         send_token_pin_authorization_transitions = [
             {'trigger': 'feed_char',
              'source': 'send_token_pin_authorization',
-             'dest': 'send_token_confirmation',
-             'conditions': 'is_authorized_pin'},
+             'dest': 'complete',
+             'conditions': 'is_authorized_pin',
+             'after': 'process_send_token_request'},
             {'trigger': 'feed_char',
              'source': 'send_token_pin_authorization',
              'dest': 'exit_pin_blocked',
              'conditions': 'is_blocked_pin'}
         ]
         self.add_transitions(send_token_pin_authorization_transitions)
-
-        # event: send_token_confirmation transitions
-        send_token_confirmation_transitions = [
-            {'trigger': 'feed_char',
-             'source': 'send_token_confirmation',
-             'dest': 'complete',
-             'after': 'process_send_token_request',
-             'conditions': 'menu_one_selected'},
-            {'trigger': 'feed_char',
-             'source': 'send_token_confirmation',
-             'dest': 'exit',
-             'conditions': 'menu_two_selected'},
-            {'trigger': 'feed_char',
-             'source': 'send_token_confirmation',
-             'dest': 'exit_invalid_menu_option'}
-        ]
-        self.add_transitions(send_token_confirmation_transitions)
 
         # event: account_management transitions
         account_management_transitions = [

--- a/app/server/utils/ussd/token_processor.py
+++ b/app/server/utils/ussd/token_processor.py
@@ -221,7 +221,11 @@ class TokenProcessor(object):
             )
 
     @staticmethod
-    def send_token(sender: User, recipient: User, amount: float, reason_str: str, reason_id: int):
+    def send_token(sender: User,
+                   recipient: User,
+                   amount: float,
+                   reason_str: Optional[str] = None,
+                   reason_id: Optional[int] = None):
         try:
             exchanged_amount = TokenProcessor.transfer_token(sender, recipient, amount, reason_id)
 

--- a/app/server/utils/ussd/ussd_tasks.py
+++ b/app/server/utils/ussd/ussd_tasks.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from server.models.user import User
 from server.models.transfer_usage import TransferUsage
 from server.utils.ussd.directory_listing_processor import DirectoryListingProcessor
@@ -11,7 +12,11 @@ class UssdTasker(object):
         processor.send_directory_listing()
 
     @staticmethod
-    def send_token(sender: User, recipient: User, amount: float, reason_str: str, reason_id: int):
+    def send_token(sender: User,
+                   recipient: User,
+                   amount: float,
+                   reason_str: Optional[str] = None,
+                   reason_id: Optional[int] = None):
         TokenProcessor.send_token(sender, recipient, amount, reason_str, reason_id)
 
     @staticmethod

--- a/config_files/public/local_config.ini
+++ b/config_files/public/local_config.ini
@@ -24,7 +24,7 @@ default_country                              = KE
 self_service_wallet_initial_disbursement     = 5000
 
 [USSD]
-valid_service_code = "*483*061#"
+valid_service_code = *483*061#
 
 [DATABASE]
 host         = localhost

--- a/test/functional/app/api/test_ussd_api.py
+++ b/test/functional/app/api/test_ussd_api.py
@@ -96,26 +96,9 @@ def test_golden_path_send_token(mocker, test_client,
     assert "CON Enter Amount" in resp
 
     resp = req("12.5", test_client, sender)
-    assert "CON Transfer Reason" in resp
-    assert f"1. {top_priority.translations['en']}" in resp
-    assert "9." in resp
-
-    resp = req("9", test_client, sender)
-    assert "CON Please specify" in resp
-    assert "10. Show previous" in resp
-    assert "9." not in resp
-
-    resp = req("10", test_client, sender)
-
-    resp = req("4", test_client, sender)
-    assert "CON Please enter your PIN" in resp
+    assert "CON Send 12.5 SM1" in resp
 
     resp = req("0000", test_client, sender)
-    assert "CON Send 12.5 SM1" in resp
-    # went to second page, should not be the first
-    assert f"for {top_priority.translations['en']}" not in resp
-
-    resp = req("1", test_client, sender)
     assert "END Your request has been sent." in resp
 
     assert default_transfer_account(sender).balance == (4220 - 100 - 100 - 1250)
@@ -131,11 +114,11 @@ def test_golden_path_send_token(mocker, test_client,
 
 
 def test_invalid_service_code(mocker, test_client,
-                                init_database, initialised_blockchain_network, init_seed):
+                              init_database, initialised_blockchain_network, init_seed):
 
     org = OrganisationFactory()
     sender = UserFactory(preferred_language="en", phone=make_kenyan_phone(phone()), first_name="Bob", last_name="Foo",
-        pin_hash=User.salt_hash_secret('0000'), default_organisation=org)
+                         pin_hash=User.salt_hash_secret('0000'), default_organisation=org)
 
     resp = req("", test_client, sender, '*42*666#')
     assert 'END Bonyeza {} kutumia mtandao'.format(valid_service_code) in resp

--- a/test/helpers/ussd_tasker.py
+++ b/test/helpers/ussd_tasker.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from server.models.user import User
 from server.models.transfer_usage import TransferUsage
 
@@ -8,7 +9,11 @@ class MockUssdTasker(object):
         pass
 
     @staticmethod
-    def send_token(sender: User, recipient: User, amount: float, reason_str: str, reason_id: int):
+    def send_token(sender: User,
+                   recipient: User,
+                   amount: float,
+                   reason_str: Optional[str] = None,
+                   reason_id: Optional[int] = None):
         pass
 
     @staticmethod

--- a/test/unit/app/utils/ussd/kenya/test_misc_state.py
+++ b/test/unit/app/utils/ussd/kenya/test_misc_state.py
@@ -209,5 +209,3 @@ def test_terms_only_sent_once(mocker, test_client, init_database, mock_sms_apis)
     state_machine.feed_char('0000')
 
     assert len(messages) == 1
-
-

--- a/test/unit/app/utils/ussd/kenya/test_pin_state.py
+++ b/test/unit/app/utils/ussd/kenya/test_pin_state.py
@@ -7,6 +7,7 @@ import json
 from helpers.factories import UserFactory, UssdSessionFactory, OrganisationFactory
 from server.utils.ussd.kenya_ussd_state_machine import KenyaUssdStateMachine
 from server.models.user import User
+from server import db
 from server.utils import user as user_utils
 
 fake = Faker()
@@ -22,7 +23,8 @@ pin_blocked_user = partial(base_user, pin_hash=User.salt_hash_secret('0000'), fa
 initial_pin_entry_state = partial(UssdSessionFactory, state="initial_pin_entry")
 initial_pin_confirmation_state = partial(UssdSessionFactory, state="initial_pin_confirmation",
                                          session_data=json.loads('{"initial_pin": "0000"}'))
-send_token_pin_authorization_state = partial(UssdSessionFactory, state="send_token_pin_authorization")
+send_token_pin_authorization_state = partial(UssdSessionFactory, state="send_token_pin_authorization",
+                                             session_data=json.loads('{"transaction_amount": "10" }'))
 current_pin_state = partial(UssdSessionFactory, state="current_pin")
 new_pin_state = partial(UssdSessionFactory, state="new_pin")
 new_pin_confirmation_state = partial(UssdSessionFactory, state="new_pin_confirmation",
@@ -35,23 +37,23 @@ balance_inquiry_pin_authorization_state = partial(UssdSessionFactory, state="bal
 
 
 @pytest.mark.parametrize("session_factory, user_factory, user_input, expected",
- [
-     # initial_pin_entry transitions tests
-     (initial_pin_entry_state, standard_user, "0000", "initial_pin_confirmation"),
-     (initial_pin_entry_state, standard_user, "AAAA", "exit_invalid_pin"),
-     # current_pin state tests
-     (current_pin_state, standard_user, "0000", "new_pin"),
-     (current_pin_state, pin_blocked_user, "1111", "exit_pin_blocked"),
-     # new_pin state tests
-     (new_pin_state, standard_user, "2222", "new_pin_confirmation"),
-     (new_pin_state, standard_user, "0000", "exit_invalid_pin"),
-     # new_pin_confirmation state tests
-     (new_pin_confirmation_state, standard_user, "2222", "complete"),
-     (new_pin_confirmation_state, standard_user, "1212", "exit_pin_mismatch"),
-     # opt_out_of_market_place_pin_authorization state tests
-     (opt_out_of_market_place_pin_authorization_state, pin_blocked_user, "1111",
-      "exit_pin_blocked")
- ])
+                         [
+                             # initial_pin_entry transitions tests
+                             (initial_pin_entry_state, standard_user, "0000", "initial_pin_confirmation"),
+                             (initial_pin_entry_state, standard_user, "AAAA", "exit_invalid_pin"),
+                             # current_pin state tests
+                             (current_pin_state, standard_user, "0000", "new_pin"),
+                             (current_pin_state, pin_blocked_user, "1111", "exit_pin_blocked"),
+                             # new_pin state tests
+                             (new_pin_state, standard_user, "2222", "new_pin_confirmation"),
+                             (new_pin_state, standard_user, "0000", "exit_invalid_pin"),
+                             # new_pin_confirmation state tests
+                             (new_pin_confirmation_state, standard_user, "2222", "complete"),
+                             (new_pin_confirmation_state, standard_user, "1212", "exit_pin_mismatch"),
+                             # opt_out_of_market_place_pin_authorization state tests
+                             (opt_out_of_market_place_pin_authorization_state, pin_blocked_user, "1111",
+                              "exit_pin_blocked")
+                         ])
 def test_kenya_state_machine(test_client, init_database, user_factory, session_factory, user_input, expected):
     from flask import g
     g.active_organisation = OrganisationFactory(country_code='AU')
@@ -71,12 +73,10 @@ def test_kenya_state_machine(test_client, init_database, user_factory, session_f
      (send_token_pin_authorization_state, pin_blocked_user, "1212", "exit_pin_blocked", 3, 3),
      (send_token_pin_authorization_state, standard_user, "1212",
       "send_token_pin_authorization", 1, 2),
-     (send_token_pin_authorization_state, standard_user, "0000",
-      "send_token_confirmation", 1, 0),
+     (send_token_pin_authorization_state, standard_user, "0000", "complete", 1, 0),
      (send_token_pin_authorization_state, standard_user, "1212",
       "exit_pin_blocked", 2, 3),
-     (send_token_pin_authorization_state, standard_user, "0000",
-      "send_token_confirmation", 2, 0),
+     (send_token_pin_authorization_state, standard_user, "0000", "complete", 2, 0),
      # balance inquiry pin auth combinations
      (balance_inquiry_pin_authorization_state, pin_blocked_user, "1212", "exit_pin_blocked", 3, 3),
      (balance_inquiry_pin_authorization_state, standard_user, "1212",
@@ -110,15 +110,16 @@ def test_kenya_state_machine(test_client, init_database, user_factory, session_f
  ])
 def test_authorize_pin(test_client, init_database, session_factory, user_factory, user_input, expected,
                        before_failed_pin_attempts, after_failed_pin_attempts):
-    session = session_factory()
-    user = user_factory(phone='+6140000000')
-    user.failed_pin_attempts = before_failed_pin_attempts
+    with db.session.no_autoflush:
+        session = session_factory()
+        user = user_factory(phone='+6140000000')
+        user.failed_pin_attempts = before_failed_pin_attempts
 
-    state_machine = KenyaUssdStateMachine(session, user)
+        state_machine = KenyaUssdStateMachine(session, user)
 
-    state_machine.feed_char(user_input)
-    assert state_machine.state == expected
-    assert user.failed_pin_attempts == after_failed_pin_attempts
+        state_machine.feed_char(user_input)
+        assert state_machine.state == expected
+        assert user.failed_pin_attempts == after_failed_pin_attempts
 
 
 def test_change_initial_pin(mocker, test_client, init_database):

--- a/test/unit/app/utils/ussd/kenya/test_pin_state.py
+++ b/test/unit/app/utils/ussd/kenya/test_pin_state.py
@@ -37,23 +37,23 @@ balance_inquiry_pin_authorization_state = partial(UssdSessionFactory, state="bal
 
 
 @pytest.mark.parametrize("session_factory, user_factory, user_input, expected",
-                         [
-                             # initial_pin_entry transitions tests
-                             (initial_pin_entry_state, standard_user, "0000", "initial_pin_confirmation"),
-                             (initial_pin_entry_state, standard_user, "AAAA", "exit_invalid_pin"),
-                             # current_pin state tests
-                             (current_pin_state, standard_user, "0000", "new_pin"),
-                             (current_pin_state, pin_blocked_user, "1111", "exit_pin_blocked"),
-                             # new_pin state tests
-                             (new_pin_state, standard_user, "2222", "new_pin_confirmation"),
-                             (new_pin_state, standard_user, "0000", "exit_invalid_pin"),
-                             # new_pin_confirmation state tests
-                             (new_pin_confirmation_state, standard_user, "2222", "complete"),
-                             (new_pin_confirmation_state, standard_user, "1212", "exit_pin_mismatch"),
-                             # opt_out_of_market_place_pin_authorization state tests
-                             (opt_out_of_market_place_pin_authorization_state, pin_blocked_user, "1111",
-                              "exit_pin_blocked")
-                         ])
+ [
+     # initial_pin_entry transitions tests
+     (initial_pin_entry_state, standard_user, "0000", "initial_pin_confirmation"),
+     (initial_pin_entry_state, standard_user, "AAAA", "exit_invalid_pin"),
+     # current_pin state tests
+     (current_pin_state, standard_user, "0000", "new_pin"),
+     (current_pin_state, pin_blocked_user, "1111", "exit_pin_blocked"),
+     # new_pin state tests
+     (new_pin_state, standard_user, "2222", "new_pin_confirmation"),
+     (new_pin_state, standard_user, "0000", "exit_invalid_pin"),
+     # new_pin_confirmation state tests
+     (new_pin_confirmation_state, standard_user, "2222", "complete"),
+     (new_pin_confirmation_state, standard_user, "1212", "exit_pin_mismatch"),
+     # opt_out_of_market_place_pin_authorization state tests
+     (opt_out_of_market_place_pin_authorization_state, pin_blocked_user, "1111",
+      "exit_pin_blocked")
+ ])
 def test_kenya_state_machine(test_client, init_database, user_factory, session_factory, user_input, expected):
     from flask import g
     g.active_organisation = OrganisationFactory(country_code='AU')
@@ -71,42 +71,28 @@ def test_kenya_state_machine(test_client, init_database, user_factory, session_f
  [
      # send token pin auth combinations
      (send_token_pin_authorization_state, pin_blocked_user, "1212", "exit_pin_blocked", 3, 3),
-     (send_token_pin_authorization_state, standard_user, "1212",
-      "send_token_pin_authorization", 1, 2),
+     (send_token_pin_authorization_state, standard_user, "1212", "send_token_pin_authorization", 1, 2),
      (send_token_pin_authorization_state, standard_user, "0000", "complete", 1, 0),
-     (send_token_pin_authorization_state, standard_user, "1212",
-      "exit_pin_blocked", 2, 3),
+     (send_token_pin_authorization_state, standard_user, "1212", "exit_pin_blocked", 2, 3),
      (send_token_pin_authorization_state, standard_user, "0000", "complete", 2, 0),
      # balance inquiry pin auth combinations
      (balance_inquiry_pin_authorization_state, pin_blocked_user, "1212", "exit_pin_blocked", 3, 3),
-     (balance_inquiry_pin_authorization_state, standard_user, "1212",
-      "balance_inquiry_pin_authorization", 1, 2),
-     (balance_inquiry_pin_authorization_state, standard_user, "0000",
-      "complete", 1, 0),
-     (balance_inquiry_pin_authorization_state, standard_user, "1212",
-      "exit_pin_blocked", 2, 3),
-     (balance_inquiry_pin_authorization_state, standard_user, "0000",
-      "complete", 2, 0),
+     (balance_inquiry_pin_authorization_state, standard_user, "1212", "balance_inquiry_pin_authorization", 1, 2),
+     (balance_inquiry_pin_authorization_state, standard_user, "0000", "complete", 1, 0),
+     (balance_inquiry_pin_authorization_state, standard_user, "1212", "exit_pin_blocked", 2, 3),
+     (balance_inquiry_pin_authorization_state, standard_user, "0000", "complete", 2, 0),
      # exchange token pin auth combinations
      (exchange_token_pin_authorization_state, pin_blocked_user, "1111", "exit_pin_blocked", 3, 3),
-     (exchange_token_pin_authorization_state, standard_user, "1212",
-      "exchange_token_pin_authorization", 1, 2),
-     (exchange_token_pin_authorization_state, standard_user, "0000",
-      "exchange_token_confirmation", 1, 0),
-     (exchange_token_pin_authorization_state, standard_user, "1212",
-      "exit_pin_blocked", 2, 3),
-     (exchange_token_pin_authorization_state, standard_user, "0000",
-      "exchange_token_confirmation", 2, 0),
+     (exchange_token_pin_authorization_state, standard_user, "1212", "exchange_token_pin_authorization", 1, 2),
+     (exchange_token_pin_authorization_state, standard_user, "0000", "exchange_token_confirmation", 1, 0),
+     (exchange_token_pin_authorization_state, standard_user, "1212", "exit_pin_blocked", 2, 3),
+     (exchange_token_pin_authorization_state, standard_user, "0000", "exchange_token_confirmation", 2, 0),
      # exchange rate pin auth combinations
      (exchange_rate_pin_authorization_state, pin_blocked_user, "1111", "exit_pin_blocked", 3, 3),
-     (exchange_rate_pin_authorization_state, standard_user, "1212",
-      "exchange_rate_pin_authorization", 1, 2),
-     (exchange_rate_pin_authorization_state, standard_user, "0000",
-      "complete", 1, 0),
-     (exchange_rate_pin_authorization_state, standard_user, "1212",
-      "exit_pin_blocked", 2, 3),
-     (exchange_rate_pin_authorization_state, standard_user, "0000",
-      "complete", 2, 0),
+     (exchange_rate_pin_authorization_state, standard_user, "1212", "exchange_rate_pin_authorization", 1, 2),
+     (exchange_rate_pin_authorization_state, standard_user, "0000", "complete", 1, 0),
+     (exchange_rate_pin_authorization_state, standard_user, "1212", "exit_pin_blocked", 2, 3),
+     (exchange_rate_pin_authorization_state, standard_user, "0000", "complete", 2, 0),
  ])
 def test_authorize_pin(test_client, init_database, session_factory, user_factory, user_input, expected,
                        before_failed_pin_attempts, after_failed_pin_attempts):

--- a/test/unit/app/utils/ussd/kenya/test_send_state.py
+++ b/test/unit/app/utils/ussd/kenya/test_send_state.py
@@ -35,45 +35,19 @@ def standard_user(test_client, init_database):
 
 send_enter_recipient_state = partial(UssdSessionFactory, state="send_enter_recipient")
 send_token_amount_state = partial(UssdSessionFactory, state="send_token_amount")
-send_token_reason_state = partial(UssdSessionFactory, state="send_token_reason")
-send_token_reason_other_state = partial(UssdSessionFactory, state="send_token_reason_other")
 send_token_pin_authorization_state = partial(UssdSessionFactory, state="send_token_pin_authorization")
-send_token_confirmation_state = partial(UssdSessionFactory, state="send_token_confirmation")
 
 
 @pytest.mark.parametrize("session_factory, user_input, expected",
  [
      # send_token_amount state test
-     (send_token_amount_state, "12.5", "send_token_reason"),
-     (send_token_amount_state, "500", "send_token_reason"),
+     (send_token_amount_state, "12.5", "send_token_pin_authorization"),
+     (send_token_amount_state, "500", "send_token_pin_authorization"),
      (send_token_amount_state, "-1", "exit_invalid_input"),
-     (send_token_amount_state, "asdf", "exit_invalid_input"),
-     # send_token_reasons state tests
-     (send_token_reason_state, "9", "send_token_reason_other"),
-     (send_token_reason_state, "1", "send_token_pin_authorization"),
-     (send_token_reason_state, "10", "exit_invalid_menu_option"),
-     (send_token_reason_state, "11", "exit_invalid_menu_option"),
-     (send_token_reason_state, "asdf", "exit_invalid_menu_option"),
-     # send_token_reason_other state tests
-     (send_token_reason_other_state, "1", "send_token_pin_authorization"),
-     (send_token_reason_other_state, "9", "send_token_reason_other"),
-     (send_token_reason_other_state, "10", "send_token_reason_other"),
-     (send_token_reason_other_state, "11", "exit_invalid_menu_option"),
-     (send_token_reason_other_state, "asdf", "exit_invalid_menu_option"),
-     # send_token_pin_authorization state tests
-     (send_token_pin_authorization_state, "0000", "send_token_confirmation"),
-     # send_token_confirmation state tests
-     (send_token_confirmation_state, "2", "exit"),
-     (send_token_confirmation_state, "3", "exit_invalid_menu_option"),
-     (send_token_confirmation_state, "asdf", "exit_invalid_menu_option"),
+     (send_token_amount_state, "asdf", "exit_invalid_input")
  ])
 def test_kenya_state_machine(test_client, init_database, standard_user, session_factory, user_input, expected):
     session = session_factory()
-    session.session_data = {
-        'transfer_usage_mapping': fake_transfer_mapping(10),
-        'usage_menu': 1,
-        'usage_index_stack': [0, 8]
-    }
     db.session.commit()
     state_machine = KenyaUssdStateMachine(session, standard_user)
 
@@ -160,22 +134,20 @@ def test_send_token(mocker, test_client, init_database, create_transfer_account_
     recipient = create_transfer_account_user
     recipient.phone = make_kenyan_phone(recipient.phone)
 
-    send_token_confirmation = UssdSessionFactory(
-        state="send_token_confirmation",
+    send_token_pin_authorization = UssdSessionFactory(
+        state="send_token_pin_authorization",
         session_data=json.loads(
             "{" +
             f'"recipient_phone": "{recipient.phone}",'
-            '"transaction_amount": "10",'
-            '"transaction_reason_i18n": "A reason",'
-            '"transaction_reason_id": "1"'
+            '"transaction_amount": "10"'
             + "}"
         )
     )
 
-    state_machine = KenyaUssdStateMachine(send_token_confirmation, standard_user)
+    state_machine = KenyaUssdStateMachine(send_token_pin_authorization, standard_user)
     send_token = mocker.MagicMock()
     mocker.patch('server.ussd_tasker.send_token', send_token)
 
-    state_machine.feed_char("1")
+    state_machine.feed_char("0000")
     assert state_machine.state == "complete"
-    send_token.assert_called_with(standard_user, recipient, 10, "A reason", 1)
+    send_token.assert_called_with(sender=standard_user, recipient=recipient, amount=10.0)

--- a/test/unit/app/utils/ussd/kenya/test_send_state.py
+++ b/test/unit/app/utils/ussd/kenya/test_send_state.py
@@ -39,13 +39,13 @@ send_token_pin_authorization_state = partial(UssdSessionFactory, state="send_tok
 
 
 @pytest.mark.parametrize("session_factory, user_input, expected",
- [
-     # send_token_amount state test
-     (send_token_amount_state, "12.5", "send_token_pin_authorization"),
-     (send_token_amount_state, "500", "send_token_pin_authorization"),
-     (send_token_amount_state, "-1", "exit_invalid_input"),
-     (send_token_amount_state, "asdf", "exit_invalid_input")
- ])
+                         [
+                             # send_token_amount state test
+                             (send_token_amount_state, "12.5", "send_token_pin_authorization"),
+                             (send_token_amount_state, "500", "send_token_pin_authorization"),
+                             (send_token_amount_state, "-1", "exit_invalid_input"),
+                             (send_token_amount_state, "asdf", "exit_invalid_input")
+                         ])
 def test_kenya_state_machine(test_client, init_database, standard_user, session_factory, user_input, expected):
     session = session_factory()
     db.session.commit()
@@ -150,4 +150,4 @@ def test_send_token(mocker, test_client, init_database, create_transfer_account_
 
     state_machine.feed_char("0000")
     assert state_machine.state == "complete"
-    send_token.assert_called_with(sender=standard_user, recipient=recipient, amount=10.0)
+    send_token.assert_called_with(standard_user, recipient=recipient, amount=10.0)


### PR DESCRIPTION
**Describe the Pull Request**

This bug changes the send token flow of the ussd send token process. It removes the need to confirm what a user bought and initiates the sending of the actual token on entry of the user pin.

https://github.com/GrassrootsEconomics/CIC-Docs/projects/1#card-35821324
