### PR TITLE
Adds requested changes to receipt messages.

### DIFF
--- a/app/migrations/seed.py
+++ b/app/migrations/seed.py
@@ -347,6 +347,11 @@ def create_ussd_menus():
         description='The self signup process has been initiated and the account is being created.'
     )
 
+    update_or_create_menu(
+        name='exit_successful_send_token',
+        description='The payment transaction has been made successfully.',
+    )
+
     print_section_conclusion('Done creating USSD Menus')
 
 

--- a/app/server/locale/ussd.en.yml
+++ b/app/server/locale/ussd.en.yml
@@ -44,7 +44,7 @@ en:
         10. Show previous
     send_token_pin_authorization:
       first: |
-        CON Send %{transaction_amount} %{token_name} to %{recipient_phone}.
+        CON %{other_user_details} will receive %{transaction_amount} %{token_name} from %{user_details}.
         Please enter your PIN to confirm.
         0. Back
       retry: |
@@ -228,6 +228,8 @@ en:
     exit_use_exchange_menu: END Recipient phone number is an agent. To exchange, use exchange menu
     exit_invalid_token_agent: END Agent phone number is incorrect
     exit_account_creation_prompt: END Your account is being created. You will receive an SMS when your account is ready.
+    exit_successful_send_token: |
+      END Your request has been sent. %{other_user_details} will receive %{transaction_amount} %{token_name} from%{user_details}. You will receive an SMS shortly.
     exit_not_registered: |
       END Kusajili tuma: jina, nambari ya simu, eneo na biashara yako kwa 0757628885
       To register send: name, number, location and business to 0757628885

--- a/app/server/locale/ussd.en.yml
+++ b/app/server/locale/ussd.en.yml
@@ -237,8 +237,8 @@ en:
     upsell_message_recipient: "%{first_name} %{last_name} tried to send you %{token_name} but you are not registered. Send your information: name, phone number, area of residence, and the type of business you run 0757628885."
     send_directory_listing_message: "%{community_token_name} %{business_type} Market\n%{directory_listing_users}"
     no_directory_listing_found_message: Sorry we couldn't find businesses from your community that match your search criteria.
-    send_token_sender_sms: Successfully sent a payment of %{amount} %{token_name} to %{other_user} on %{date} at %{time}. New %{token_name} balance is %{balance}
-    send_token_recipient_sms: Successfully received a payment of %{amount} %{token_name} from %{other_user} on %{date} at %{time}. New %{token_name} balance is %{balance}
+    send_token_sender_sms: Successfully sent a payment of %{amount} %{token_name} to %{other_user_details} on %{date} at %{time} from %{user_details}. New %{token_name} balance is %{balance}
+    send_token_recipient_sms: Successfully received a payment of %{amount} %{token_name} from %{other_user_details} on %{date} at %{time} to %{user_details}. New %{token_name} balance is %{balance}
     exchange_token_sender_sms: Successfully sent a payment of %{own_amount} %{own_token_name} = %{other_amount} %{other_token_name} to %{other_user} on %{date} at %{time}. New %{own_token_name} balance is %{balance}
     exchange_token_agent_sms: Successfully received a payment of %{own_amount} %{own_token_name} = %{other_amount} %{other_token_name} from %{other_user} on %{date} at %{time}. New %{own_token_name} balance is %{balance}
     exchange_rate_can_exchange_sms: |

--- a/app/server/locale/ussd.sw.yml
+++ b/app/server/locale/ussd.sw.yml
@@ -234,8 +234,8 @@ sw:
     upsell_message_recipient: "%{first_name} %{last_name} amejaribu kukutumia %{token_name} lakini hujasajili. Tuma maelezo yako: jina, eneo, na aina ya biashara yako kwa 0757628885."
     send_directory_listing_message: "%{community_token_name} Soko ya %{business_type}\n%{directory_listing_users}"
     no_directory_listing_found_message: Samahani hatukuweza kupata biashara kutoka kwa jumuiya yako inayofanana na utafutaji wako.
-    send_token_sender_sms: Umetuma %{amount} %{token_name} kwa %{other_user} tarehe %{date} saa %{time}. Salio lako la %{token_name} ni %{balance}
-    send_token_recipient_sms: Umepokea %{amount} %{token_name} kutoka kwa %{other_user} tarehe %{date} saa %{time}. Salio lako la %{token_name} ni %{balance}
+    send_token_sender_sms: Umetuma %{amount} %{token_name} kwa %{other_user_details} tarehe %{date} saa %{time} kutoka kwa %{user_details}. Salio lako la %{token_name} ni %{balance}
+    send_token_recipient_sms: Umepokea %{amount} %{token_name} kutoka kwa %{other_user_details} tarehe %{date} saa %{time} iliyotumwa kwa %{user_details}. Salio lako la %{token_name} ni %{balance}
     exchange_token_sender_sms: Umetuma %{own_amount} %{own_token_name} = %{other_amount} %{other_token_name} kwa %{other_user} tarehe %{date} saa %{time}. Salio lako la %{own_token_name} ni %{balance}
     exchange_token_agent_sms: Umepokea %{own_amount} %{own_token_name} = %{other_amount} %{other_token_name} kutoka kwa %{other_user} tarehe %{date} saa %{time}. Salio lako la %{own_token_name} ni %{balance}
     exchange_rate_can_exchange_sms: |

--- a/app/server/locale/ussd.sw.yml
+++ b/app/server/locale/ussd.sw.yml
@@ -44,9 +44,9 @@ sw:
         10. Onyesha chaguzi zilizopita
     send_token_pin_authorization:
       first: |
-        CON Tuma %{transaction_amount} %{token_name} kwa %{recipient_phone}.
-        Weka nambari ya siri kuthibitisha.
-        0. Nyuma
+        CON %{other_user_details} atapokea %{transaction_amount} %{token_name} kutoka kwa %{user_details}.
+        Tafadhali weka nambari yako ya siri kudhibitisha.
+        0. Back
       retry: |
         CON Weka nambari ya siri. Una majaribio %{remaining_attempts} yaliyobaki.
         0. Nyuma
@@ -221,6 +221,8 @@ sw:
     exit_invalid_recipient: END Mpokeaji wa nambari hapatikani au sio sahihi
     exit_use_exchange_menu: END Mpokeaji wa nambari ni wakala. Ili kubadilisha, tumia ubadilishaji
     exit_invalid_token_agent: END wakala wa nambari hapatikani au sio sahihi
+    exit_successful_send_token: |
+      END Ombi lako limetumwa. %{other_user_details} atapokea %{transaction_amount} %{token_name} kutoka kwa %{user_details}. Utapokea ujumbe mfupi kwa sms.
     exit_not_registered: |
       END Haujasajiliwa kwa Sarafu. Kusajili tuma: jina, nambari ya simu, eneo na biashara yako kwa 0757628885
     exit_invalid_exchange_amount: END Kiwango ulichoweka hakitoshi. Tafadhali weka kiwango cha 40 au zaidi.

--- a/app/server/models/user.py
+++ b/app/server/models/user.py
@@ -664,8 +664,11 @@ class User(ManyOrgBase, ModelBase, SoftDelete):
         return self.pin_hash is not None and not_resetting and self.failed_pin_attempts < 3
 
     def user_details(self):
-        # should drop the country code from phone number?
-        return "{} {} {}".format(self.first_name, self.last_name, self.phone)
+        # return phone numbers only if any of user's details are unknown
+        if 'Unknown' in self.first_name or 'Unknown' in self.last_name:
+            return "{}".format(self.phone)
+        else:
+            return "{} {} {}".format(self.first_name, self.last_name, self.phone)
 
     def get_most_relevant_transfer_usages(self):
         '''Finds the transfer usage/business categories there are most relevant for the user

--- a/app/server/utils/ussd/kenya_ussd_processor.py
+++ b/app/server/utils/ussd/kenya_ussd_processor.py
@@ -132,7 +132,8 @@ class KenyaUssdProcessor:
 
         if menu.name == 'send_token_pin_authorization':
             recipient = get_user_by_phone(ussd_session.get_data('recipient_phone'), 'KE', True)
-            recipient_phone = recipient.user_details()
+            other_user_details = recipient.user_details()
+            user_details = user.user_details()
             token = default_token(user)
             transaction_amount = ussd_session.get_data('transaction_amount')
             if user.failed_pin_attempts > 0:
@@ -147,8 +148,26 @@ class KenyaUssdProcessor:
                     key="{}.{}".format(menu.display_key, 'first'),
                     transaction_amount=cents_to_dollars(transaction_amount),
                     token_name=token.symbol,
-                    recipient_phone=recipient_phone
+                    other_user_details=other_user_details,
+                    user_details=user_details
+
                 )
+
+        if menu.name == 'exit_successful_send_token':
+            recipient = get_user_by_phone(ussd_session.get_data('recipient_phone'), 'KE', True)
+            other_user_details = recipient.user_details()
+            user_details = user.user_details()
+            token = default_token(user)
+            transaction_amount = ussd_session.get_data('transaction_amount')
+            return i18n_for(
+                user=user,
+                key="{}".format(menu.display_key, 'exit_successful_send_token'),
+                transaction_amount=cents_to_dollars(transaction_amount),
+                token_name=token.symbol,
+                other_user_details=other_user_details,
+                user_details=user_details
+
+            )
 
         if menu.name == 'exchange_token_confirmation':
             agent = get_user_by_phone(ussd_session.get_data('agent_phone'), 'KE', True)

--- a/app/server/utils/ussd/kenya_ussd_state_machine.py
+++ b/app/server/utils/ussd/kenya_ussd_state_machine.py
@@ -95,6 +95,7 @@ class KenyaUssdStateMachine(Machine):
         'exit_invalid_token_agent',
         'exit_invalid_exchange_amount',
         'exit_account_creation_prompt',
+        'exit_successful_send_token',
         State(name='complete', on_enter=['send_terms_to_user_if_required'])
     ]
 
@@ -668,7 +669,7 @@ class KenyaUssdStateMachine(Machine):
         send_token_pin_authorization_transitions = [
             {'trigger': 'feed_char',
              'source': 'send_token_pin_authorization',
-             'dest': 'complete',
+             'dest': 'exit_successful_send_token',
              'conditions': 'is_authorized_pin',
              'after': 'process_send_token_request'},
             {'trigger': 'feed_char',

--- a/app/server/utils/ussd/token_processor.py
+++ b/app/server/utils/ussd/token_processor.py
@@ -45,8 +45,13 @@ class TokenProcessor(object):
         amount_dollars = rounded_dollars(amount)
         rounded_balance_dollars = rounded_dollars(balance)
 
-        TokenProcessor.send_sms(user, message_key, amount=amount_dollars, token_name=default_token(user).symbol,
-                                other_user=other_user.user_details(), date=tx_time.strftime('%d/%m/%Y'),
+        TokenProcessor.send_sms(user=user,
+                                message_key=message_key,
+                                amount=amount_dollars,
+                                token_name=default_token(user).symbol,
+                                user_details=user.user_details(),
+                                other_user_details=other_user.user_details(),
+                                date=tx_time.strftime('%d/%m/%Y'),
                                 time=tx_time.strftime('%I:%M %p'), balance=rounded_balance_dollars)
 
     @staticmethod
@@ -232,20 +237,20 @@ class TokenProcessor(object):
             recipient_balance = TokenProcessor.get_balance(recipient)
             if exchanged_amount is None:
                 TokenProcessor.send_success_sms(
-                    "send_token_sender_sms",
-                    sender,
-                    recipient,
-                    amount,
-                    sender_tx_time,
-                    sender_balance)
+                    message_key="send_token_sender_sms",
+                    user=sender,
+                    other_user=recipient,
+                    amount=amount,
+                    tx_time=sender_tx_time,
+                    balance=sender_balance)
 
                 TokenProcessor.send_success_sms(
-                    "send_token_recipient_sms",
-                    recipient,
-                    sender,
-                    amount,
-                    recipient_tx_time,
-                    recipient_balance)
+                    message_key="send_token_recipient_sms",
+                    user=recipient,
+                    other_user=sender,
+                    amount=amount,
+                    tx_time=recipient_tx_time,
+                    balance=recipient_balance)
             else:
                 TokenProcessor.exchange_success_sms(
                     "exchange_token_sender_sms",

--- a/test/functional/app/api/test_ussd_api.py
+++ b/test/functional/app/api/test_ussd_api.py
@@ -200,13 +200,20 @@ def test_ussd_self_signup_wrong_pin_entry(test_client,
     resp = req("", test_client, other_unregistered_user_phone)
     assert "CON Welcome to Sarafu" in resp
 
-    resp = req("1", test_client, other_unregistered_user_phone, auth_username=external_auth_username)
+    # create self signup user
+    user = UserFactory(id=22,
+                       phone=other_unregistered_user_phone,
+                       first_name='Unknown first name',
+                       last_name='Unknown last name',
+                       registration_method=RegistrationMethodEnum.USSD_SIGNUP)
+
+    resp = req("1", test_client, user.phone, auth_username=external_auth_username)
     assert "CON Please enter a PIN" in resp
 
-    resp = req("0000", test_client, other_unregistered_user_phone, auth_username=external_auth_username)
+    resp = req("0000", test_client, user.phone, auth_username=external_auth_username)
     assert "CON Enter your PIN again" in resp
 
-    resp = req("1212", test_client, other_unregistered_user_phone, auth_username=external_auth_username)
+    resp = req("1212", test_client, user.phone, auth_username=external_auth_username)
     assert "END The new PIN does not match the one you entered." in resp
 
 

--- a/test/functional/app/api/test_ussd_api.py
+++ b/test/functional/app/api/test_ussd_api.py
@@ -60,7 +60,7 @@ def test_golden_path_send_token(mocker, test_client, init_database, initialised_
     token = Token.query.filter_by(symbol="SM1").first()
     org = OrganisationFactory(country_code=config.DEFAULT_COUNTRY)
     sender = UserFactory(preferred_language="en",
-                         phone=make_kenyan_phone(phone()),
+                         phone='+6110011223344',
                          first_name="Bob",
                          last_name="Foo",
                          pin_hash=User.salt_hash_secret('0000'),
@@ -68,7 +68,7 @@ def test_golden_path_send_token(mocker, test_client, init_database, initialised_
     create_transfer_account_for_user(sender, token, 4220)
 
     recipient = UserFactory(preferred_language="sw",
-                            phone=make_kenyan_phone(phone()),
+                            phone='+6114433221100',
                             first_name="Joe",
                             last_name="Bar",
                             default_organisation=org)
@@ -116,7 +116,7 @@ def test_golden_path_send_token(mocker, test_client, init_database, initialised_
     assert "CON Enter Amount" in resp
 
     resp = req("12.5", test_client, sender.phone)
-    assert "CON Send 12.5 SM1" in resp
+    assert f"{recipient.user_details()} will receive 12.5 {token.symbol} from {sender.user_details()}" in resp
 
     resp = req("0000", test_client, sender.phone)
     assert "END Your request has been sent." in resp
@@ -124,11 +124,11 @@ def test_golden_path_send_token(mocker, test_client, init_database, initialised_
     assert default_transfer_account(sender).balance == (4220 - 100 - 100 - 1250)
     assert default_transfer_account(recipient).balance == (1980 + 100 + 100 + 1250)
 
-    assert len(messages) == 3
-    sent_message = messages[1]
+    assert len(messages) == 2
+    sent_message = messages[0]
     assert sent_message['phone'] == sender.phone
     assert f"sent a payment of 12.50 SM1 to {recipient.first_name}" in sent_message['message']
-    received_message = messages[2]
+    received_message = messages[1]
     assert received_message['phone'] == recipient.phone
     assert f"Umepokea 12.50 SM1 kutoka kwa {sender.first_name}" in received_message['message']
 
@@ -200,20 +200,13 @@ def test_ussd_self_signup_wrong_pin_entry(test_client,
     resp = req("", test_client, other_unregistered_user_phone)
     assert "CON Welcome to Sarafu" in resp
 
-    # create self signup user
-    user = UserFactory(id=22,
-                       phone=other_unregistered_user_phone,
-                       first_name='Unknown first name',
-                       last_name='Unknown last name',
-                       registration_method=RegistrationMethodEnum.USSD_SIGNUP)
-
-    resp = req("1", test_client, user.phone, auth_username=external_auth_username)
+    resp = req("1", test_client, other_unregistered_user_phone, auth_username=external_auth_username)
     assert "CON Please enter a PIN" in resp
 
-    resp = req("0000", test_client, user.phone, auth_username=external_auth_username)
+    resp = req("0000", test_client, other_unregistered_user_phone, auth_username=external_auth_username)
     assert "CON Enter your PIN again" in resp
 
-    resp = req("1212", test_client, user.phone, auth_username=external_auth_username)
+    resp = req("1212", test_client, other_unregistered_user_phone, auth_username=external_auth_username)
     assert "END The new PIN does not match the one you entered." in resp
 
 

--- a/test/unit/app/utils/ussd/kenya/test_pin_state.py
+++ b/test/unit/app/utils/ussd/kenya/test_pin_state.py
@@ -72,9 +72,9 @@ def test_kenya_state_machine(test_client, init_database, user_factory, session_f
      # send token pin auth combinations
      (send_token_pin_authorization_state, pin_blocked_user, "1212", "exit_pin_blocked", 3, 3),
      (send_token_pin_authorization_state, standard_user, "1212", "send_token_pin_authorization", 1, 2),
-     (send_token_pin_authorization_state, standard_user, "0000", "complete", 1, 0),
+     (send_token_pin_authorization_state, standard_user, "0000", "exit_successful_send_token", 1, 0),
      (send_token_pin_authorization_state, standard_user, "1212", "exit_pin_blocked", 2, 3),
-     (send_token_pin_authorization_state, standard_user, "0000", "complete", 2, 0),
+     (send_token_pin_authorization_state, standard_user, "0000", "exit_successful_send_token", 2, 0),
      # balance inquiry pin auth combinations
      (balance_inquiry_pin_authorization_state, pin_blocked_user, "1212", "exit_pin_blocked", 3, 3),
      (balance_inquiry_pin_authorization_state, standard_user, "1212", "balance_inquiry_pin_authorization", 1, 2),

--- a/test/unit/app/utils/ussd/kenya/test_send_state.py
+++ b/test/unit/app/utils/ussd/kenya/test_send_state.py
@@ -149,5 +149,5 @@ def test_send_token(mocker, test_client, init_database, create_transfer_account_
     mocker.patch('server.ussd_tasker.send_token', send_token)
 
     state_machine.feed_char("0000")
-    assert state_machine.state == "complete"
+    assert state_machine.state == "exit_successful_send_token"
     send_token.assert_called_with(standard_user, recipient=recipient, amount=10.0)


### PR DESCRIPTION
This pull request implements the requested amendment on the token send receipt messages as requested in the issue below:
https://github.com/GrassrootsEconomics/CIC-Docs/issues/104
It also defaults to displaying a user's phone number in the event that their name information is not set.
