### PR TITLE
Fix alembic graph to include noop migration step in staging

### DIFF
--- a/app/migrations/versions/0da0913f9dbd_.py
+++ b/app/migrations/versions/0da0913f9dbd_.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '0da0913f9dbd'
-down_revision = '026e6bde589e'
+down_revision = '6d8a938930ff'
 branch_labels = None
 depends_on = None
 

--- a/app/migrations/versions/241af81119c4_extended_location_information.py
+++ b/app/migrations/versions/241af81119c4_extended_location_information.py
@@ -1,7 +1,7 @@
 """extended location information
 
 Revision ID: 241af81119c4
-Revises: 6d8a938930ff
+Revises: fbc9b56af590
 Create Date: 2020-04-23 11:37:45.838998
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '241af81119c4'
-down_revision = '9ce32573d450'
+down_revision = 'fbc9b56af590'
 branch_labels = None
 depends_on = None
 

--- a/app/migrations/versions/984d7e9c50af_.py
+++ b/app/migrations/versions/984d7e9c50af_.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: 984d7e9c50af
+Revises: 3500c08573ff, 026e6bde589e
+Create Date: 2020-05-01 11:14:47.831437
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '984d7e9c50af'
+down_revision = ('3500c08573ff', '026e6bde589e')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/app/migrations/versions/fbc9b56af590_.py
+++ b/app/migrations/versions/fbc9b56af590_.py
@@ -1,0 +1,24 @@
+"""empty message
+
+Revision ID: fbc9b56af590
+Revises: 984d7e9c50af, 9ce32573d450
+Create Date: 2020-05-08 13:10:21.319615
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'fbc9b56af590'
+down_revision = ('984d7e9c50af', '9ce32573d450')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
The location merge removed a noop db upgrade that was already performed in the staging environment. This PR inserts the locations based db changes on top of the current staging revision instead.