### PR TITLE
Adds hour and minute to user's creation timestamp

### DIFF
--- a/app/client/components/dateTime.jsx
+++ b/app/client/components/dateTime.jsx
@@ -4,7 +4,7 @@ import moment from "moment";
 export default class DateTime extends React.Component {
   render() {
     if (this.props.created) {
-      var formatted_time = new Date(this.props.created).toDateString();
+      var formatted_time = new Date(this.props.created).toLocaleString();
 
       return <div style={{ margin: 0 }}>{formatted_time}</div>;
     } else {


### PR DESCRIPTION
This PR adds hours and minutes to the user creation timestamp in the user's table on the GUI.

https://gitlab.com/grassrootseconomics/cic-platform-temp/-/issues/34