### PR TITLE
Add EB config & Nginx routes for USSD API

### DIFF
--- a/awsDockerrunTemplate.json
+++ b/awsDockerrunTemplate.json
@@ -30,6 +30,34 @@
       ]
     },
     {
+      "name": "ussd",
+      "image": "REPOSITORY_URI:server_TAG_SUFFIX",
+      "essential": true,
+      "memoryReservation": 256,
+      "cpu": 1,
+      "links": ["pgbouncer:pgbouncer"],
+      "environment": [
+        {
+          "name": "CONTAINER_TYPE",
+          "value": "APP"
+        },
+        {
+          "name": "SERVER_HAS_S3_AUTH",
+          "value": true
+        },
+        {
+          "name": "PYTHONUNBUFFERED",
+          "value": 0
+        }
+      ],
+      "portMappings": [
+        {
+          "hostPort": 3032,
+          "containerPort": 3031
+        }
+      ]
+    },
+    {
       "name": "pgbouncer",
       "image": "REPOSITORY_URI:pgbouncer_TAG_SUFFIX",
       "essential": true,

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -15,14 +15,14 @@ server {
     return 301 https://$host$request_uri;
   }
 
-  location / {
-        proxy_pass http://app:9000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-  }
   location ~ ^/api/v[0-9]/ussd(.*?)$ {
-      proxy_pass http://ussd:9000;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
+    proxy_pass http://ussd:9000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+  }
+  location / {
+    proxy_pass http://app:9000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
   }
 }

--- a/proxy/default.conf
+++ b/proxy/default.conf
@@ -20,4 +20,9 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
   }
+  location ~ ^/api/v[0-9]/ussd(.*?)$ {
+      proxy_pass http://ussd:9000;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+  }
 }


### PR DESCRIPTION
**Describe the Pull Request**

This PR updates the EB config to create a separate instance of the server to handle USSD API requests. It does this by using a wildcard on the Nginx router: `location ~ ^/api/v[0-9]/ussd(.*?)$ {`

All USSD requests will go to the `ussd` instance. All other requests will go to the `app` instance.
